### PR TITLE
Lolodi/using pipes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -628,11 +628,11 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+			"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
 			"requires": {
-				"follow-redirects": "1.5.10"
+				"follow-redirects": "^1.10.0"
 			}
 		},
 		"balanced-match": {
@@ -2162,27 +2162,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+			"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
 		},
 		"for-in": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Exposes an API that allows other extensions to download files.",
     "publisher": "mindaro-dev",
     "license": "MIT",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "repository": {
         "type": "git",
         "url": "https://github.com/microsoft/vscode-file-downloader.git"
@@ -53,9 +53,7 @@
         "webpack-cli": "^3.3.12"
     },
     "dependencies": {
-        "axios": "^0.19.2",
-        "extract-zip": "^2.0.1",
-        "lodash": "^4.17.19",
+        "axios": "^0.20.0",
         "rimraf": "^3.0.0",
         "unzipper": "^0.10.3",
         "uuid": "^8.0.0"

--- a/src/networking/HttpRequestHandler.ts
+++ b/src/networking/HttpRequestHandler.ts
@@ -59,7 +59,8 @@ export default class HttpRequestHandler implements IHttpRequestHandler {
     ): Promise<Readable> {
         const options: AxiosRequestConfig = {
             timeout: timeoutInMs,
-            responseType: `stream`
+            responseType: `stream`,
+            proxy: false // Disabling axios proxy support allows VS Code proxy settings to take effect.
         };
 
         if (cancellationToken != null) {
@@ -88,9 +89,11 @@ export default class HttpRequestHandler implements IHttpRequestHandler {
                 downloadStream.destroy();
             });
         }
-        // We should not feed of the data handler here if we are goign to pipe of the downloadStream later on. this forks the pipe and creates problem e.g. FILE_ENDED, PREMATURE_CLOSE
+
+        // We should not feed of the data handler here if we are going to pipe the downloadStream later on.
+        // Doing this forks the pipe and creates problem e.g. FILE_ENDED, PREMATURE_CLOSE
         // https://nodejs.org/api/stream.html#stream_choose_one_api_style
-        // We should make this progress reporter code a trasnform pipe and chain it before the unzipper.
+        // We should make this progress reporter code a transform pipe and place it between the downloadStream and the unzipper.
         // if (onDownloadProgressChange != null) {
         //     const headers: { [key: string]: any } = response.headers;
         //     const contentLength = parseInt(headers[`content-length`], 10);


### PR DESCRIPTION
Switching back to using pipes.
This should get rid of the XHR errors and make it easier to re-implement proper progress reporting going forward.