### PR TITLE
Removing the sync method as it causing long time to download binaries

### DIFF
--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -126,7 +126,7 @@ export default class FileDownloader implements IFileDownloader {
             return RetryUtility.exponentialRetryAsync(renameDownloadedFileAsyncFn, retries, retryDelayInMs);
         }
         catch (error) {
-            this._logger.error(`${error.message}. Technical details: ${JSON.stringify(error)}`);
+            this._logger.error(`Failed during post download operation with error: ${error.message}. Technical details: ${JSON.stringify(error)}`);
             throw error;
         }
     }

--- a/src/utility/FileSystem.ts
+++ b/src/utility/FileSystem.ts
@@ -4,4 +4,4 @@
 import { promisify } from "util";
 import * as rimraf from "rimraf";
 
-export const rimrafAsync = promisify(rimraf.sync);
+export const rimrafAsync = promisify(rimraf);


### PR DESCRIPTION
Removing the sync method and just depending on the original method. I'm seeing inconsistent behavior with download times. I have looked around rimraf code and they have default retries and wait times so will depend on their logic.