### PR TITLE
Double the number of retries for renaming the folder names

### DIFF
--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -123,7 +123,7 @@ export default class FileDownloader implements IFileDownloader {
                 return Uri.file(fileDownloadPath);
             };
 
-            return RetryUtility.exponentialRetryAsync(renameDownloadedFileAsyncFn, retries, retryDelayInMs);
+            return RetryUtility.exponentialRetryAsync(renameDownloadedFileAsyncFn, retries * 2, retryDelayInMs);
         }
         catch (error) {
             this._logger.error(`Failed during post download operation with error: ${error.message}. Technical details: ${JSON.stringify(error)}`);


### PR DESCRIPTION
Using the existing retries and doubling that number instead of adding a new setting for adding a retry value for just the renaming part.