### PR TITLE
Add additional error details for RetryExceededError

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Exposes an API that allows other extensions to download files.",
     "publisher": "mindaro-dev",
     "license": "MIT",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "repository": {
         "type": "git",
         "url": "https://github.com/microsoft/vscode-file-downloader.git"

--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -97,7 +97,7 @@ export default class FileDownloader implements IFileDownloader {
                     await extractZip(tempZipFileDownloadPath, { dir: tempFileDownloadPath });
                     await rimrafAsync(tempZipFileDownloadPath);
                 };
-                await RetryUtility.exponentialRetryAsync(unzipDownloadedFileAsyncFn, retries, retryDelayInMs);
+                await RetryUtility.exponentialRetryAsync(unzipDownloadedFileAsyncFn, unzipDownloadedFileAsyncFn.name, retries, retryDelayInMs);
             }
 
             // Set progress to 100%

--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -129,7 +129,7 @@ export default class FileDownloader implements IFileDownloader {
                 return Uri.file(fileDownloadPath);
             };
 
-            return RetryUtility.exponentialRetryAsync(renameDownloadedFileAsyncFn, retries, retryDelayInMs);
+            return RetryUtility.exponentialRetryAsync(renameDownloadedFileAsyncFn, renameDownloadedFileAsyncFn.name, retries, retryDelayInMs);
         }
         catch (error) {
             this._logger.error(`Failed during post download operation with error: ${error.message}. Technical details: ${JSON.stringify(error)}`);

--- a/src/networking/HttpRequestHandler.ts
+++ b/src/networking/HttpRequestHandler.ts
@@ -31,7 +31,7 @@ export default class HttpRequestHandler implements IHttpRequestHandler {
                 throw error;
             }
         };
-        return RetryUtility.exponentialRetryAsync(requestFn, retries, retryDelayInMs, errorHandlerFn);
+        return RetryUtility.exponentialRetryAsync(requestFn, `HttpRequestHandler.get`, retries, retryDelayInMs, errorHandlerFn);
     }
 
     private async getRequestHelper(

--- a/src/utility/Errors.ts
+++ b/src/utility/Errors.ts
@@ -20,9 +20,9 @@ export class FileNotFoundError extends Error {
 }
 
 export class RetriesExceededError extends Error {
-    public constructor(error: Error) {
-        super(`Maximum number of retries exceeded. The operation failed with error: ${error.message}.`);
+    public constructor(error: Error, operationName: string) {
+        super(`Maximum number of retries exceeded. The operation '${operationName}' failed with error: ${error.message}. Technical details: ${JSON.stringify(error)}`);
         Object.setPrototypeOf(this, new.target.prototype);
-        this.name = RetriesExceededError.name;
+        this.name = `${RetriesExceededError.name} for operation '${operationName}'`;
     }
 }

--- a/src/utility/RetryUtility.ts
+++ b/src/utility/RetryUtility.ts
@@ -6,6 +6,7 @@ import { RetriesExceededError } from "./Errors";
 export class RetryUtility {
     public static async exponentialRetryAsync<T>(
         requestFn: () => Promise<T>,
+        operationName: string,
         retries: number,
         initialDelayInMs: number,
         errorHandlerFn?: (error: Error) => void
@@ -15,7 +16,7 @@ export class RetryUtility {
         }
         catch (error) {
             if (retries === 0) {
-                throw new RetriesExceededError(error);
+                throw new RetriesExceededError(error, operationName);
             }
 
             if (errorHandlerFn != null) {
@@ -25,7 +26,7 @@ export class RetryUtility {
             await new Promise((resolve): void => {
                 setTimeout(resolve, initialDelayInMs);
             });
-            return this.exponentialRetryAsync(requestFn, retries - 1, initialDelayInMs * 2, errorHandlerFn);
+            return this.exponentialRetryAsync(requestFn, operationName, retries - 1, initialDelayInMs * 2, errorHandlerFn);
         }
     }
 }


### PR DESCRIPTION
In retry scenarios where the `RetryUtility.exponentialRetryAsync` is being used, with just error.message, entire stack trace and additional error details are not being thrown to the caller. So, added json format of the error thrown so that the caller would have more details about the error. Also, added the ability for the exponentialRetryAsync to take in the operationName to easily identify which retry operation failed.