### PR TITLE
Allow headers to be passed in to underlying Axios

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "VSCode File Downloader",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+
+	"postCreateCommand": "npm install -g yo generator-code && npm install",
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"amodio.tsl-problem-matcher"
+			]
+		}
+	}
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,8 +27,9 @@
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
             ],
+            "sourceMaps": true,
             "outFiles": [
-                "${workspaceFolder}/out/test/**/*.js"
+                "${workspaceFolder}/out/**/*.js"
             ],
             "preLaunchTask": "npm: test-compile"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "file-downloader",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "file-downloader",
-            "version": "1.0.11",
+            "version": "1.0.12",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.26.1",

--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -9,7 +9,7 @@ import * as extractZip from 'extract-zip';
 import { CancellationToken, ExtensionContext, Uri } from "vscode";
 import { v4 as uuid } from "uuid";
 import { rimrafAsync } from "./utility/FileSystem";
-import IFileDownloader from "./IFileDownloader";
+import IFileDownloader, { FileDownloadSettings } from "./IFileDownloader";
 import IHttpRequestHandler from "./networking/IHttpRequestHandler";
 import ILogger from "./logging/ILogger";
 import { DownloadCanceledError, ErrorUtils, FileNotFoundError } from "./utility/Errors";
@@ -19,13 +19,6 @@ import { RetryUtility } from "./utility/RetryUtility";
 const DefaultTimeoutInMs = 5000;
 const DefaultRetries = 5;
 const DefaultRetryDelayInMs = 100;
-
-export interface FileDownloadSettings {
-    timeoutInMs?: number;
-    retries?: number;
-    retryDelayInMs?: number;
-    shouldUnzip?: boolean;
-}
 
 export default class FileDownloader implements IFileDownloader {
     public constructor(
@@ -62,6 +55,7 @@ export default class FileDownloader implements IFileDownloader {
         const retries = settings?.retries ?? DefaultRetries;
         const retryDelayInMs = settings?.retryDelayInMs ?? DefaultRetryDelayInMs;
         const shouldUnzip = settings?.shouldUnzip ?? false;
+        const headers = settings?.headers;
         let progress = 0;
         let progressTimerId: any;
         try {
@@ -82,6 +76,7 @@ export default class FileDownloader implements IFileDownloader {
                 timeoutInMs,
                 retries,
                 retryDelayInMs,
+                headers,
                 cancellationToken,
                 onDownloadProgressChange
             );

--- a/src/IFileDownloader.ts
+++ b/src/IFileDownloader.ts
@@ -2,7 +2,14 @@
 // Licensed under the MIT License.
 
 import { ExtensionContext, CancellationToken, Uri } from "vscode";
-import { FileDownloadSettings } from "./FileDownloader";
+
+export interface FileDownloadSettings {
+    timeoutInMs?: number;
+    retries?: number;
+    retryDelayInMs?: number;
+    shouldUnzip?: boolean;
+    headers?: Record<string, string | number | boolean> | undefined;
+}
 
 export default interface IFileDownloader {
     downloadFile(

--- a/src/IFileDownloader.ts
+++ b/src/IFileDownloader.ts
@@ -4,10 +4,34 @@
 import { ExtensionContext, CancellationToken, Uri } from "vscode";
 
 export interface FileDownloadSettings {
+    /**
+     * Timeout in milliseconds for the request.
+     * @default 5000
+     */
     timeoutInMs?: number;
+    /**
+     * Number of retries for the request.
+     * @default 5
+     */
     retries?: number;
+    /**
+     * Delay in milliseconds between retries.
+     * @default 100
+     */
     retryDelayInMs?: number;
+    /**
+     * Whether to unzip the downloaded file.
+     * @default false
+     */
     shouldUnzip?: boolean;
+    /**
+     * Additional headers to send with the request.
+     * @default undefined
+     * @example
+     * {
+     *   headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
+     * }
+     */
     headers?: Record<string, string | number | boolean> | undefined;
 }
 

--- a/src/networking/HttpRequestHandler.ts
+++ b/src/networking/HttpRequestHandler.ts
@@ -16,12 +16,14 @@ export default class HttpRequestHandler implements IHttpRequestHandler {
         timeoutInMs: number,
         retries: number,
         retryDelayInMs: number,
+        headers?: Record<string, string | number | boolean>,
         cancellationToken?: CancellationToken,
         onDownloadProgressChange?: (downloadedBytes: number, totalBytes: number) => void
     ): Promise<Readable> {
         const requestFn = () => this.getRequestHelper(
             url,
             timeoutInMs,
+            headers,
             cancellationToken,
             onDownloadProgressChange
         );
@@ -37,13 +39,15 @@ export default class HttpRequestHandler implements IHttpRequestHandler {
     private async getRequestHelper(
         url: string,
         timeoutInMs: number,
+        headers?: Record<string, string | number | boolean>,
         cancellationToken?: CancellationToken,
         onDownloadProgressChange?: (downloadedBytes: number, totalBytes: number) => void
     ): Promise<Readable> {
         const options: AxiosRequestConfig = {
             timeout: timeoutInMs,
             responseType: `stream`,
-            proxy: false // Disabling axios proxy support allows VS Code proxy settings to take effect.
+            proxy: false, // Disabling axios proxy support allows VS Code proxy settings to take effect.
+            headers
         };
 
         if (cancellationToken != null) {

--- a/src/networking/IHttpRequestHandler.ts
+++ b/src/networking/IHttpRequestHandler.ts
@@ -10,6 +10,7 @@ export default interface IHttpRequestHandler {
         timeoutInMs: number,
         retries: number,
         retryDelayInMs: number,
+        headers?: Record<string, string | number | boolean>,
         cancellationToken?: CancellationToken,
         onDownloadProgressChange?: (downloadedBytes: number, totalBytes: number) => void
     ): Promise<Readable>;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import { ExtensionContext, extensions, Uri, window, CancellationTokenSource } from "vscode";
-import IFileDownloader from "../../IFileDownloader";
+import IFileDownloader, { FileDownloadSettings } from "../../IFileDownloader";
 import { ErrorUtils } from "../../utility/Errors";
 import { rimrafAsync } from "../../utility/FileSystem";
 
@@ -18,6 +18,8 @@ const MockExtensionContext = { globalStoragePath: MockGlobalStoragePath, globalS
 
 const TestDownloadUri = Uri.parse(`https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf`);
 const TestDownloadFilename = `test.pdf`;
+const TestDownloadUriWithSettings = Uri.parse(`https://api.github.com/repos/Azure/apiops/releases/assets/120693194`);
+const TestDownloadFilenameWithSettings = `extractor.linux-x64.exe`;
 
 suite(`Integration Tests`, () => {
     window.showInformationMessage(`Start all tests.`);
@@ -299,5 +301,24 @@ suite(`Integration Tests`, () => {
         for (const item of downloadedItems) {
             assert(!item.fsPath.includes(`50MB.zip`));
         }
+    });
+
+    test(`Simple download from GitHub`, async () => {
+        const settings: FileDownloadSettings = {
+            timeoutInMs: 20000,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
+        };
+
+        assert(
+            await fileDownloader.downloadFile(
+                TestDownloadUriWithSettings,
+                TestDownloadFilenameWithSettings,
+                MockExtensionContext,
+                undefined,
+                undefined,
+                settings
+            )
+        );
     });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -13,13 +13,13 @@ import { rimrafAsync } from "../../utility/FileSystem";
  * These tests will download files to C:\Users\<user>\AppData\Local\Programs\Microsoft VS Code\test-downloads\ and
  * delete both the files and the \test-downloads\ directory after the test is over
  */
-const MockGlobalStoragePath = path.join(process.cwd(), `/test-downloads/`);
+const MockGlobalStoragePath = path.join(__dirname, `/test-downloads/`);
 const MockExtensionContext = { globalStoragePath: MockGlobalStoragePath, globalStorageUri: Uri.file(MockGlobalStoragePath) } as ExtensionContext;
 
 const TestDownloadUri = Uri.parse(`https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf`);
 const TestDownloadFilename = `test.pdf`;
-const TestDownloadUriWithSettings = Uri.parse(`https://api.github.com/repos/Azure/apiops/releases/assets/120693194`);
-const TestDownloadFilenameWithSettings = `extractor.linux-x64.exe`;
+const TestDownloadUriWithSettings = Uri.parse(`https://api.github.com/repos/stuartleeks/pick-a-browser/releases/assets/95441770`);
+const TestDownloadFilenameWithSettings = `pick-a-browser_windows_386.zip`;
 
 suite(`Integration Tests`, () => {
     window.showInformationMessage(`Start all tests.`);
@@ -305,7 +305,6 @@ suite(`Integration Tests`, () => {
 
     test(`Simple download from GitHub`, async () => {
         const settings: FileDownloadSettings = {
-            timeoutInMs: 20000,
             // eslint-disable-next-line @typescript-eslint/naming-convention
             headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
         };

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -10,7 +10,7 @@ export const run = (): Promise<void> => {
     const mocha = new Mocha({
         ui: `tdd`,
         color: true,
-        timeout: 20000
+        timeout: 10000
     });
 
     const testsRoot = path.resolve(__dirname, `..`);

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -10,7 +10,7 @@ export const run = (): Promise<void> => {
     const mocha = new Mocha({
         ui: `tdd`,
         color: true,
-        timeout: 10000
+        timeout: 20000
     });
 
     const testsRoot = path.resolve(__dirname, `..`);


### PR DESCRIPTION
This Pull Request adds the following items.

- A VSCode Dev Container so that all pre-requisites are installed for the repository
- You can now debug the tests in the devcontainer
- Add the ability to pass a Record into the downloadFile method. This will represent the `Headers` that a user can define when required. This is particularly useful when you wish to download binaries from GitHub Releases and you need a `application/octet-stream` Content-Type

Fixes #38
Fixes #39 

Tests all passing
![image](https://github.com/microsoft/vscode-file-downloader/assets/6254153/b2df4f5f-191a-49de-be78-2a8a8d075969)
