### PR TITLE
Make downloaded file executable

### DIFF
--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -55,6 +55,7 @@ export default class FileDownloader implements IFileDownloader {
         const retries = settings?.retries ?? DefaultRetries;
         const retryDelayInMs = settings?.retryDelayInMs ?? DefaultRetryDelayInMs;
         const shouldUnzip = settings?.shouldUnzip ?? false;
+        const makeExecutable = settings?.makeExecutable ?? false;
         const headers = settings?.headers;
         let progress = 0;
         let progressTimerId: any;
@@ -126,6 +127,9 @@ export default class FileDownloader implements IFileDownloader {
             const renameDownloadedFileAsyncFn = async (): Promise<Uri> => {
                 // Move the temp file/folder to its permanent location and return it
                 await fs.promises.rename(tempFileDownloadPath, fileDownloadPath);
+                if (makeExecutable) {
+                    await fs.promises.chmod(fileDownloadPath, 0o700);
+                }
                 return Uri.file(fileDownloadPath);
             };
 

--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -122,9 +122,10 @@ export default class FileDownloader implements IFileDownloader {
 
         // Make the file executable if requested
         // File permissions are preserved after moving the file
+        // Files are downloaded with 0o644 file permissions
         try {
             if (makeExecutable) {
-                await fs.promises.chmod(tempFileDownloadPath, 0o700);
+                await fs.promises.chmod(tempFileDownloadPath, 0o744);
             }
         }
         catch (error) {

--- a/src/IFileDownloader.ts
+++ b/src/IFileDownloader.ts
@@ -25,6 +25,11 @@ export interface FileDownloadSettings {
      */
     shouldUnzip?: boolean;
     /**
+     * Whether to make the downloaded file executable.
+     * @default false
+     */
+    makeExecutable?: boolean;
+    /**
      * Additional headers to send with the request.
      * @default undefined
      * @example

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -309,7 +309,7 @@ suite(`Integration Tests`, () => {
             headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
         };
 
-        assert(
+        const downloadedFile: Uri =
             await fileDownloader.downloadFile(
                 TestDownloadUriWithSettings,
                 TestDownloadFilenameWithSettings,
@@ -317,7 +317,43 @@ suite(`Integration Tests`, () => {
                 undefined,
                 undefined,
                 settings
-            )
-        );
+            );
+
+        assert(downloadedFile != null);
+
+        const stats = await fs.promises.stat(downloadedFile.fsPath);
+        const fileSizeInBytes = stats.size;
+        assert(fileSizeInBytes > 0);
     });
+
+    test(`Make executable`, async () => {
+        const settings: FileDownloadSettings = {
+            makeExecutable: true,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
+        };
+
+        const downloadedFile: Uri =
+            await fileDownloader.downloadFile(
+                TestDownloadUriWithSettings,
+                TestDownloadFilenameWithSettings,
+                MockExtensionContext,
+                undefined,
+                undefined,
+                settings
+            );
+
+        assert(downloadedFile != null);
+
+        const stats = await fs.promises.stat(downloadedFile.fsPath);
+        const fileSizeInBytes = stats.size;
+        assert(fileSizeInBytes > 0);
+
+
+        await fs.promises.access(downloadedFile.fsPath, fs.constants.X_OK)
+            .catch((error: Error) => {
+                assert.fail(`File is not executable: ${error}`);
+            });
+    });
+
 });


### PR DESCRIPTION
This PR allows you to download a file from somewhere and allow the user to be able to execute it.

By setting the `makeExecutable` setting to `true` (default of `false`), it will set the user permission to 0o700 (rwx)

Fixes #43 