### PR TITLE
GitHub Authentication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,13 @@ jobs:
         npm run compile
     - name: Smoke test (Linux)
       run: xvfb-run -a npm run test
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       if: runner.os == 'Linux'
     - name: Smoke test (Mac, Windows)
       run: npm run test
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       if: runner.os != 'Linux'
     - name: Package Extension
       if: matrix.os == 'ubuntu-latest'

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import { ExtensionContext } from "vscode";
-import FileDownloader from "./FileDownloader";
+import { FileDownloader } from "./FileDownloader";
 import HttpRequestHandler from "./networking/HttpRequestHandler";
-import IFileDownloader from "./IFileDownloader";
+import { IFileDownloader } from "./IFileDownloader";
 import OutputLogger from "./logging/OutputLogger";
 
 // Called when the extension is activated

--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -172,7 +172,7 @@ export class FileDownloader implements IFileDownloader {
         }
         catch (error) {
             if (error instanceof Error) {
-                this._logger.error(`Failed cannot be made executable: ${error.message}. Technical details: ${JSON.stringify(error)}`);
+                this._logger.error(`File cannot be made executable: ${tempFileDownloadPath}. Technical details: ${JSON.stringify(error)}`);
             }
             throw error;
         }
@@ -253,7 +253,7 @@ export class FileDownloader implements IFileDownloader {
     // Example:
     // https://github.com/microsoft/vscode/releases/latest
     // owner: microsoft
-    // repo: vscode
+    // repository: vscode
     // fileName: 1.8.3.zip
     // Returns: Either a link or undefined.
     private async getGitHubDownloadLink(
@@ -270,8 +270,8 @@ export class FileDownloader implements IFileDownloader {
             }
         }
         catch (error) {
-            // Maybe GitHub is is down, don't stop the extension from working.
-            this._logger.error(`${error}. Technical details: ${JSON.stringify(error)}`);
+            // Maybe GitHub is down, don't stop the extension from working.
+            this._logger.error(`Failed to access https://api.github.com/repos/${owner}/${repository} for ${fileName}. Technical details: ${JSON.stringify(error)}`);
         }
 
         this._logger.error(`${fileName} not found in latest release.`);

--- a/src/IFileDownloader.ts
+++ b/src/IFileDownloader.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ExtensionContext, CancellationToken, Uri } from "vscode";
+import { CancellationToken, ExtensionContext, Uri } from "vscode";
 
 export interface FileDownloadSettings {
     /**
@@ -34,13 +34,13 @@ export interface FileDownloadSettings {
      * @default undefined
      * @example
      * {
-     *   headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
+     *   headers: {"Accept": `application/octet-stream`}
      * }
      */
     headers?: Record<string, string | number | boolean> | undefined;
 }
 
-export default interface IFileDownloader {
+export interface IFileDownloader {
     /**
      * Downloads a file from a URL and gives back the file path, file name, and a checksum. Allows you to specify the
      * timeout, the number of acceptable retries, whether or not to unzip the file, and whether or not to check the
@@ -59,6 +59,35 @@ export default interface IFileDownloader {
     downloadFile(
         url: Uri,
         filename: string,
+        context: ExtensionContext,
+        cancellationToken?: CancellationToken,
+        onDownloadProgressChange?: (downloadedBytes: number, totalBytes: number | undefined) => void,
+        settings?: FileDownloadSettings
+    ): Promise<Uri>;
+    /**
+     * Downloads a file from a GitHub release and gives back the file path, file name, and a checksum. Allows you to
+     * specify the timeout, the number of acceptable retries, whether or not to unzip the file, and whether or not to
+     * check the downloaded file against a checksum.
+     *
+     * @param owner the owner of the repository
+     * @param repository the repository to download from
+     * @param fileName the name of the file to download
+     * @param context the context for the extension downloading the file
+     * @param cancellationToken token that allows cancelling the download
+     * @param onDownloadProgressChange a callback that gets called every time a new chunk of data comes from the server.
+     * Note: the totalBytes parameter corresponds to the content-length provided by the server in the GET response
+     * header. It could differ from the actual number of bytes in the download, or may not be provided at all.
+     * @param settings optional additional settings for the download.
+     * @returns the URI containing the path to the downloaded file or unzipped directory
+     * @throws Error if the file is not found in the latest release
+     * @example downloadFileFromGitHubRelease(`microsoft`, `vscode`, `VSCode-linux-x64.zip`, context);
+     * @remarks This method is a wrapper around `downloadFile` that constructs the URL for the latest release of a
+     * GitHub repository.
+     */
+    downloadFileFromGitHubRelease(
+        owner: string,
+        repository: string,
+        fileName: string,
         context: ExtensionContext,
         cancellationToken?: CancellationToken,
         onDownloadProgressChange?: (downloadedBytes: number, totalBytes: number | undefined) => void,

--- a/src/IFileDownloader.ts
+++ b/src/IFileDownloader.ts
@@ -41,6 +41,21 @@ export interface FileDownloadSettings {
 }
 
 export default interface IFileDownloader {
+    /**
+     * Downloads a file from a URL and gives back the file path, file name, and a checksum. Allows you to specify the
+     * timeout, the number of acceptable retries, whether or not to unzip the file, and whether or not to check the
+     * downloaded file against a checksum.
+     *
+     * @param url the URL to make a GET request to
+     * @param filename the name of the file to retrieve the stored data in
+     * @param context the ExtensionContext of the extension downloading the file
+     * @param cancellationToken token that allows cancelling the download
+     * @param onDownloadProgressChange a callback that gets called every time a new chunk of data comes from the server.
+     * Note: the totalBytes parameter corresponds to the content-length provided by the server in the GET response
+     * header. It could differ from the actual number of bytes in the download, or may not be provided at all.
+     * @param settings optional additional settings for the download
+     * @returns the URI containing the path to the downloaded file or unzipped directory
+     */
     downloadFile(
         url: Uri,
         filename: string,
@@ -49,14 +64,44 @@ export default interface IFileDownloader {
         onDownloadProgressChange?: (downloadedBytes: number, totalBytes: number | undefined) => void,
         settings?: FileDownloadSettings
     ): Promise<Uri>;
-
+    /**
+     * Returns the paths of all files that exist in the consumer extensions' download folder
+     *
+     * @param context the context for the extension downloading the file
+     * @returns an array of downloaded file or folder paths
+     */
     listDownloadedItems(context: ExtensionContext): Promise<Uri[]>;
-
+    /**
+     * Gets the path to a downloaded or unzipped item.
+     *
+     * @param filename the name of the file or folder to remove
+     * @param context The calling extension's context
+     * @returns the path to the downloaded file (or folder if the download was unzipped)
+     * @throws FileNotFoundError if there is no such file or folder
+     */
     getItem(filename: string, context: ExtensionContext): Promise<Uri>;
-
+    /**
+     * Gets the path to a downloaded or unzipped item, but returns undefined instead of throwing an error if the file
+     * isn't found.
+     *
+     * @param filename the name of the file or folder to remove
+     * @param context The calling extension's context
+     * @returns the path to the downloaded file (or folder if the download was unzipped)
+     */
     tryGetItem(filename: string, context: ExtensionContext): Promise<Uri | undefined>;
-
+    /**
+     * Deletes the file specified by `filename`. The filename should match the name that the file was downloaded with.
+     * Does not throw an error if the file doesn't exist, as the filesystem is already in the desired state.
+     *
+     * @param filename the name of the file or folder to remove
+     * @context the context of the extension that downloaded the file
+     */
     deleteItem(filename: string, context: ExtensionContext): Promise<void>;
-
+    /**
+     * Clears all files downloaded by the extension specified in the context. Does nothing if no files have been
+     * downloaded.
+     *
+     * @param context the context of the extension that downloaded the file(s)
+     */
     deleteAllItems(context: ExtensionContext): Promise<void>;
 }

--- a/src/IGitHubRelease.ts
+++ b/src/IGitHubRelease.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+interface IGithubRelease {
+    url:              string;
+    assets_url:       string;
+    upload_url:       string;
+    html_url:         string;
+    id:               number;
+    author:           object;
+    node_id:          string;
+    tag_name:         string;
+    target_commitish: string;
+    name:             string;
+    draft:            boolean;
+    prerelease:       boolean;
+    created_at:       Date;
+    published_at:     Date;
+    assets:           IAsset[];
+    tarball_url:      string;
+    zipball_url:      string;
+    body:             string;
+    mentions_count:   number;
+}
+
+interface IAsset {
+    url:                  string;
+    id:                   number;
+    node_id:              string;
+    name:                 string;
+    label:                string;
+    uploader:             object;
+    content_type:         string;
+    state:                string;
+    size:                 number;
+    download_count:       number;
+    created_at:           Date;
+    updated_at:           Date;
+    browser_download_url: string;
+}

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -19,7 +19,8 @@ const main = async () => {
         await runTests({ extensionDevelopmentPath, extensionTestsPath });
     }
     catch (error) {
-        console.error('Failed to run tests');
+        // eslint-disable-next-line no-console
+        console.error(`Failed to run tests`);
         process.exit(1);
     }
 };

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import { ExtensionContext, extensions, Uri, window, CancellationTokenSource } from "vscode";
-import IFileDownloader, { FileDownloadSettings } from "../../IFileDownloader";
+import { IFileDownloader, FileDownloadSettings } from "../../IFileDownloader";
 import { ErrorUtils } from "../../utility/Errors";
 import { rimrafAsync } from "../../utility/FileSystem";
 
@@ -18,8 +18,6 @@ const MockExtensionContext = { globalStoragePath: MockGlobalStoragePath, globalS
 
 const TestDownloadUri = Uri.parse(`https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf`);
 const TestDownloadFilename = `test.pdf`;
-const TestDownloadUriWithSettings = Uri.parse(`https://api.github.com/repos/stuartleeks/pick-a-browser/releases/assets/95441770`);
-const TestDownloadFilenameWithSettings = `pick-a-browser_windows_386.zip`;
 
 suite(`Integration Tests`, () => {
     window.showInformationMessage(`Start all tests.`);
@@ -303,20 +301,18 @@ suite(`Integration Tests`, () => {
         }
     });
 
-    test(`Simple download from GitHub`, async () => {
-        const settings: FileDownloadSettings = {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
-        };
+    // This test will add the required headers to the request and download the file
+    test(`GitHub download`, async () => {
 
         const downloadedFile: Uri =
-            await fileDownloader.downloadFile(
-                TestDownloadUriWithSettings,
-                TestDownloadFilenameWithSettings,
+            await fileDownloader.downloadFileFromGitHubRelease(
+                `stuartleeks`,
+                `pick-a-browser`,
+                `pick-a-browser_windows_386.zip`,
                 MockExtensionContext,
                 undefined,
                 undefined,
-                settings
+                undefined
             );
 
         assert(downloadedFile != null);
@@ -326,17 +322,17 @@ suite(`Integration Tests`, () => {
         assert(fileSizeInBytes > 0);
     });
 
-    test(`Make executable`, async () => {
+    test(`GitHub Release executable`, async () => {
+
         const settings: FileDownloadSettings = {
-            makeExecutable: true,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
+            makeExecutable: true
         };
 
         const downloadedFile: Uri =
-            await fileDownloader.downloadFile(
-                TestDownloadUriWithSettings,
-                TestDownloadFilenameWithSettings,
+            await fileDownloader.downloadFileFromGitHubRelease(
+                `stuartleeks`,
+                `pick-a-browser`,
+                `pick-a-browser_windows_386.zip`,
                 MockExtensionContext,
                 undefined,
                 undefined,
@@ -348,7 +344,6 @@ suite(`Integration Tests`, () => {
         const stats = await fs.promises.stat(downloadedFile.fsPath);
         const fileSizeInBytes = stats.size;
         assert(fileSizeInBytes > 0);
-
 
         await fs.promises.access(downloadedFile.fsPath, fs.constants.X_OK)
             .catch((error: Error) => {
@@ -356,4 +351,30 @@ suite(`Integration Tests`, () => {
             });
     });
 
+    test(`Make executable`, async () => {
+        const settings: FileDownloadSettings = {
+            makeExecutable: true
+        };
+
+        const downloadedFile: Uri =
+            await fileDownloader.downloadFile(
+                TestDownloadUri,
+                TestDownloadFilename,
+                MockExtensionContext,
+                undefined,
+                undefined,
+                settings
+            );
+
+        assert(downloadedFile != null);
+
+        const stats = await fs.promises.stat(downloadedFile.fsPath);
+        const fileSizeInBytes = stats.size;
+        assert(fileSizeInBytes > 0);
+
+        await fs.promises.access(downloadedFile.fsPath, fs.constants.X_OK)
+            .catch((error: Error) => {
+                assert.fail(`File is not executable: ${error}`);
+            });
+    });
 });


### PR DESCRIPTION
This Pull Request fixes two things

1) The [FileDownloader.ts ](https://github.com/microsoft/vscode-file-downloader-api/blob/master/src/FileDownloader.ts) file in the api repo is a direct copy of IFileDownloader.ts in this repo - so make the comments the same.

2) Fixes #46 - I've added a new method `downloadFileFromGitHubRelease` which wraps the need for the particular heading we need and adds the GITHUB_TOKEN (if present) so that we are authenticated. This means that you dont have to manipulate the releases api.

NOTE TO REVIEWER
This only downloads the `latest` release. It will need to be amended to take a version if you think this is a useful addition.