### PR TITLE
VsCode Capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,16 @@
     "categories": [
         "Other"
     ],
+    "capabilities": {
+        "virtualWorkspaces": {
+            "supported": false,
+            "description": "This extension writes to the file system."
+        },
+        "untrustedWorkspaces": {
+            "supported": true,
+            "description": "This extension does not write to the workspace location."
+        }
+    },
     "activationEvents": [],
     "main": "./dist/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     ],
     "capabilities": {
         "virtualWorkspaces": {
-            "supported": false,
-            "description": "This extension writes to the file system."
+            "supported": true,
+            "description": "This extension does not write to the workspace location."
         },
         "untrustedWorkspaces": {
             "supported": true,


### PR DESCRIPTION
Adding 2 capabilities to the extension to inform vscode whether this extension would effect workspace features

- virtualWorkspaces
- untrustedWorkspaces

This extension downloads files to the data directory used by vscode and does not use the /workspaces/ location for anything

Closes #21 
Closes #22

This will not build until #54 is merged.