### PR TITLE
Add ability to skip aggressive vscode.Uri encoding

### DIFF
--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -99,6 +99,7 @@ export class FileDownloader implements IFileDownloader {
         const shouldUnzip = settings?.shouldUnzip ?? false;
         const makeExecutable = settings?.makeExecutable ?? false;
         const headers = settings?.headers;
+        const skipEncoding = settings?.skipEncoding ?? false
         let progress = 0;
         let progressTimerId: any;
         try {
@@ -115,7 +116,7 @@ export class FileDownloader implements IFileDownloader {
             }, 1500);
 
             const downloadStream: Readable = await this._requestHandler.get(
-                url.toString(),
+                url.toString(skipEncoding),
                 timeoutInMs,
                 retries,
                 retryDelayInMs,

--- a/src/IFileDownloader.ts
+++ b/src/IFileDownloader.ts
@@ -38,6 +38,11 @@ export interface FileDownloadSettings {
      * }
      */
     headers?: Record<string, string | number | boolean> | undefined;
+    /**
+     * Whether to skip aggressive encoding on the URI, as `vscode.Uri.toString()` normally results in `&` and `=` becoming encoded.
+     * @default false
+     */
+    skipEncoding?: boolean
 }
 
 export interface IFileDownloader {


### PR DESCRIPTION
Adds a field in the FileDownloadSettings to disable aggressive encoding for the `url.toString` call on line 118 of `FileDownloader.ts`. This fixes https://github.com/microsoft/vscode-file-downloader/issues/56.